### PR TITLE
Remove references to in-person WASD

### DIFF
--- a/content/event_info.md
+++ b/content/event_info.md
@@ -1,19 +1,17 @@
 <div markdown="1" class="column is-6">
 <div markdown="1" class="content">
 
-Started in 2016, WASD (Warwick's Awesome Speedruns and Demos) is a 2-day speedrunning event run annually at the University of Warwick. It is the largest student-run speedrunning event in the UK. Past events have featured a diverse range of games, from Final Fantasy IX to Rise of the Tomb Raider, from Super Monkey Ball to Parasite Eve II. WASD 2021 will run on the 13th and 14th February 2021, with the event schedule to be confirmed mid-December 2020.
+Started in 2016, WASD (Warwick's Awesome Speedruns and Demos) is a 2-day speedrunning event run annually at the University of Warwick. It is the largest student-run speedrunning event in the UK. Past events have featured a diverse range of games, from Final Fantasy IX to Rise of the Tomb Raider, from Super Monkey Ball to Parasite Eve II. WASD 2021 will run on the 13th and 14th February 2021. The event schedule has been finalised and can be found [here](https://oengus.io/marathon/wasd-2021/schedule).
 
-Donations to the event are in support of [SpecialEffect](https://specialeffect.org.uk/), a wonderful UK-based charity whose mission is to put fun and inclusion back into the lives of people with physical disabilities, by helping them to play video games. They do this by using and developing a range of accessibility hardware and software, from modified joypads to eye-gaze technology. The WASD to date events have raised over £5,000 for SpecialEffect!
+Donations to the event are in support of [SpecialEffect](https://specialeffect.org.uk/), a wonderful UK-based charity whose mission is to put fun and inclusion back into the lives of people with physical disabilities, by helping them to play video games. They do this by using and developing a range of accessibility hardware and software, from modified joypads to eye-gaze technology. The WASD events to date have raised over £5,000 for SpecialEffect!
 
 <h4 class="title is-size-4">When</h4>
 
-WASD 2021 begins at **10AM UTC** on **13th February 2021**.
+WASD 2021 begins at **12PM UTC** on **13th February 2021**.
 
 <h4 class="title is-size-4">Where</h4>
 
-We intend to host WASD 2021 at **Warwick Students' Union, University of Warwick** in **Coventry, United Kingdom**. Due to the ongoing pandemic **we cannot guarantee the event will happen in person**, and if necessary we will **host the event online instead**.
-
-WASD 2021 will be **streamed live on Twitch** on the [Warwick's Awesome Speedruns and Demos](https://twitch.tv/warwickspeedrun) Twitch channel.
+Due to the ongoing coronavirus pandemic, **WASD 2021 will be held fully remotely**. WASD 2021 will be **streamed live on Twitch** on the [Warwick's Awesome Speedruns and Demos](https://twitch.tv/warwickspeedrun) Twitch channel.
 
 </div>
 
@@ -25,14 +23,6 @@ WASD 2021 will be **streamed live on Twitch** on the [Warwick's Awesome Speedrun
 <h4 class="title is-size-4">Who</h4>
 
 WASD is run by a committee of students and alumni of the University of Warwick, with support from the University of Warwick Computing Society and Warwick Esports. You can get in contact with the organisers by [email](mailto:wasd@warwick.gg) or on [Discord](https://wasd.warwick.gg/discord).
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5182.932569470427!2d-1.5633123600885481!3d52.3804864266804!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48774ac696d53ee5%3A0xaa928d75708b2b54!2sUniversity%20of%20Warwick!5e0!3m2!1sen!2suk!4v1567157959013!5m2!1sen!2suk" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
-
-<h4 class="title is-size-4">How to get here</h4>
-
-The University of Warwick has fantastic connections with the city of Coventry, which is easily accessible by the national rail network. The campus is very close to and signposted on both the A45 and A46 roads. Coventry is also 20 minute train journey away from Birmingham International airport.
-
-More information on how to get to WASD 2021 will be available in our infopack when it becomes available.
 
 </div>
 

--- a/content/whats_on.md
+++ b/content/whats_on.md
@@ -6,22 +6,8 @@ Two days of speedrunning in aid of [SpecialEffect](https://specialeffect.org) st
 </div>
 
 <div class="content" markdown="1">
-#### Practice Space
-![A runner practicing at the event](http://localhost:8080/dist/img/practise.jpg)
-
-The practice area is a dedicated space for you to trim off some seconds or master that difficult skip while waiting for your run.
-</div>
-
-<div class="content" markdown="1">
 #### Welcoming Community
 ![Spectators enjoying themselves at the event](http://localhost:8080/dist/img/community.jpg)
 
 Our events have a wonderful sense of community and we welcome everyone with open arms.
-</div>
-
-<div class="content" markdown="1">
-#### Convenient Facilities
-![Nearby food outlets and grocers make it easy to stay well fed and hydrated](http://localhost:8080/dist/img/facilities.jpg)
-
-There are plenty of convenient local shops and facilities, from grocery stores to coffee shops.
 </div>


### PR DESCRIPTION
This PR does two things:
- Update event_info.md and whats_on.md to remove reference to in-person events.
-  Clarify that the start time is 12pm on the 13th, and link to the (now finalised) schedule.

Note that there is now less text: probably want to check that the website still looks OK (that there isn't a bunch of whitespace) before deploying. I can write more copy if needed.