### PR TITLE
Add signup button for WASD Summer 2021

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -88,6 +88,8 @@
         </p>
         <p id="countdown"><strong>WASD Summer</strong> starts on <strong>14th August 2021</strong> in <strong id="days">93 days</strong>, <strong id="hours">15
           hours</strong> and <strong id="mins">23 minutes</strong></p>
+        <a target="_blank" href="https://oengus.io/marathon/wasd-s2021" class="button is-wasd">Sign up</a>
+        <!--<p><small>Sign ups close 23:59 UTC on 4th December 2020</small></p>-->
       </div>
     </div>
   </div>
@@ -174,7 +176,9 @@
     <div class="columns" id="signupBottom">
       <div class="column is-8 is-offset-2">
         <div class="content has-text-centered">
-          <p>Signups for WASD Summer 2021 will be opening soon. Interested in some of our previous events in the meantime? Check out our VODS <a href="https://wasd.warwick.gg/vods">here</a>.</p>
+          <p>Want to take part in WASD Summer 2021? <strong>Submit a run!</strong></p>
+          <a target="_blank" href="https://oengus.io/marathon/wasd-s2021" class="button is-medium is-wasd">Sign up</a>
+          <!--<p><small>Sign ups close on the 4th December 2020 at 23:59 UTC.</small></p>-->
 <!--          <p>Signups for WASD2021 have closed, but you can still take part by watching along on our <a href="https://twitch.tv/warwickspeedrun">Twitch channel</a>.</p>-->
         </div>
       </div>


### PR DESCRIPTION
This PR adds signup buttons for WASD Summer 2021 linking to our Oengus page.

I've left the "Signups close" text commented out for now as we mentioned in Discord we can close it when we want but I can easily add it in with a date.