### PR TITLE
Remove esports from partners list

### DIFF
--- a/content/partners_list.md
+++ b/content/partners_list.md
@@ -1,5 +1,4 @@
 <div class="logos" markdown="span">
 [![University of Warwick Computing Society](http://localhost:8080/dist/img/uwcs.png)](https://uwcs.co.uk)
 [![Warwick SU](http://localhost:8080/dist/img/su-logo.png)](https://warwicksu.com)
-[![Warwick Esports](http://localhost:8080/dist/img/warwick-esports.png)](https://warwickesports.com)
 </div>


### PR DESCRIPTION
Removes the esports logo from the partners list, can always re-add in the future