### PR TITLE
Point content to new domain

### DIFF
--- a/build.py
+++ b/build.py
@@ -30,6 +30,6 @@ with open(os.path.join("index.html"), mode="w") as out_file:
     content = jinja_template.render(**rendered_content)
     # Remove development mode content from the template
     if not dev_flag:
-        content = content.replace('http://localhost:8080', 'https://wasd.warwick.gg')
+        content = content.replace('http://localhost:8080', 'https://warwickspeed.run')
 
     out_file.write(content)

--- a/content/event_info.md
+++ b/content/event_info.md
@@ -22,7 +22,7 @@ WASD Summer 2021 will be held entirely remotely and streamed live on the WASD [T
 
 <h4 class="title is-size-4">Who</h4>
 
-WASD is run by a committee of students and alumni of the University of Warwick, with support from the University of Warwick Computing Society and Warwick Esports. You can get in contact with the organisers by [email](mailto:wasd@warwick.gg) or on [Discord](https://wasd.warwick.gg/discord).
+WASD is run by a committee of students and alumni of the University of Warwick, with support from the University of Warwick Computing Society and Warwick Esports. You can get in contact with the organisers by [email](mailto:wasd@warwick.gg) or on [Discord](https://warwickspeed.run/discord).
 
 </div>
 

--- a/templates/template.html
+++ b/templates/template.html
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon-precomposed" sizes="180x180" href="http://localhost:8080/dist/favicon-180.png">
   <link rel="apple-touch-icon-precomposed" sizes="152x152" href="http://localhost:8080/dist/favicon-152.png">
   <link rel="apple-touch-icon-precomposed" sizes="120x120" href="http://localhost:8080/dist/favicon-120.png">
-  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="http://localhost:8080/dist /favicon-76.png">
+  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="http://localhost:8080/dist/favicon-76.png">
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="http://localhost:8080/dist/favicon-57.png">
 
   <!-- Favicons -->
@@ -38,7 +38,7 @@
   <link rel="stylesheet" href="http://localhost:8080/dist/css/wasd.bundle.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css"
         integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-  <link rel="cannonical" href="https://wasd.warwick.gg">
+  <link rel="cannonical" href="https://warwickspeed.run">
 
   <meta property="og:image" content="http://localhost:8080/dist/img/og-avatar.png">
   <meta property="og:image:width" content="400px">
@@ -49,17 +49,17 @@
   <meta property="og:description"
         content="A student-led speedrunning marathon in the UK supporting SpecialEffect starting 14th August 2021.">
   <meta property="og:locale" content="en_GB">
-  <meta property="og:url" content="https://wasd.warwick.gg">
+  <meta property="og:url" content="https://warwickspeed.run">
 <body>
 <section class="hero wasd-gradient">
   <nav class="navbar" role="navigation" aria-label="main navigation">
     <div class="container">
       <div class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" target="_blank" href="https://wasd.warwick.gg/vods">VODs</a>
+          <a class="navbar-item" target="_blank" href="https://warwickspeed.run/vods">VODs</a>
         </div>
         <div class="navbar-end">
-          <a class="navbar-item" target="_blank" href="https://wasd.warwick.gg/discord"><i class="fab fa-discord"></i>
+          <a class="navbar-item" target="_blank" href="https://warwickspeed.run/discord"><i class="fab fa-discord"></i>
             Discord</a>
         </div>
       </div>
@@ -196,7 +196,7 @@
         <div class="column is-4 has-text-centered-mobile">
           <h3 class="socials-title is-size-4 title">Socials</h4>
             <ul class="socials">
-              <li><a target="_blank" href="https://wasd.warwick.gg/discord"><i class="fab fa-discord"></i></a></li>
+              <li><a target="_blank" href="https://warwickspeed.run/discord"><i class="fab fa-discord"></i></a></li>
               <li><a target="_blank" href="https://twitter.com/warwickspeedrun"><i class="fab fa-twitter"></i></a></li>
               <li><a target="_blank" href="https://twitch.tv/warwickspeedrun"><i class="fab fa-twitch"></i></a></li>
               <li><a target="_blank" href="https://www.youtube.com/channel/UCrQLf-vqI47qzSWOeODR_6g"><i


### PR DESCRIPTION
This PR should now point everything to warwickspeed.run instead of wasd.warwick.gg following the recent domain switch (hopefully I've got every link).

I haven't removed references to localhost yet (see discussion in Discord) but can do that at another point.